### PR TITLE
feature: set defaults run workdir

### DIFF
--- a/.github/workflows/01-basics.yml
+++ b/.github/workflows/01-basics.yml
@@ -8,25 +8,30 @@ on:
     paths:
       - "01-Basics/**"
 
+defaults:
+  run:
+    working-directory: 01-Basics
+
 jobs:
-    code_quality:
-        name: Code Quality
-        runs-on: ubuntu-24.04
+  code_quality:
+    name: Code Quality
+    runs-on: ubuntu-24.04
 
-        steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-        - name: Setup Java 21
-          uses: actions/setup-java@v4
-          with:
-            java-version: '21'
-            distribution: 'corretto'
+    - name: Setup Java 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
 
-        - name: Run Checkstyle
-          run: ./gradlew ktlintCheck
+    - name: Run Checkstyle
+      working-directory: 01-Basics
+      run: ./gradlew ktlintCheck
 
-        - name: Running Horusec Security
-          run: |
-            curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s v2.8.0
-            horusec start -p="./" -e="true"  
+    - name: Running Horusec Security
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s v2.8.0
+        horusec start -p="./" -e="true"  


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for the `01-Basics` directory to improve the consistency and reliability of the workflow execution.

Workflow directory and job configuration updates:

* [`.github/workflows/01-basics.yml`](diffhunk://#diff-94724b9a95e4ae3772cc270ce7dacf2632f3198ce2a6f7ae2468bc27039013a8R11-R14): Added `defaults` section to set the `working-directory` to `01-Basics` for all `run` commands.
* [`.github/workflows/01-basics.yml`](diffhunk://#diff-94724b9a95e4ae3772cc270ce7dacf2632f3198ce2a6f7ae2468bc27039013a8R31): Set the `working-directory` to `01-Basics` for the `Run Checkstyle` job.